### PR TITLE
TelegramTarget - Added Layout support for BaseUrl + BotToken + ChatId

### DIFF
--- a/NLog.Telegram.Format.sln
+++ b/NLog.Telegram.Format.sln
@@ -5,6 +5,11 @@ VisualStudioVersion = 16.0.31205.134
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NLog.Telegram.Format", "Nlog.Telegram\NLog.Telegram.Format.csproj", "{E0373899-6A47-4A1F-AA17-1F8B4ACBE0D9}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{7442E4FD-298A-4ADD-B0F3-E1F7EABBEAEF}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Nlog.Telegram/NLog.Telegram.Format.csproj
+++ b/Nlog.Telegram/NLog.Telegram.Format.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>Nlog.Telegram</RootNamespace>
-    <Version>1.0.4</Version>
+    <Version>2.0.0</Version>
 
     <Description>
 An NLog target for Telegram Messenger
@@ -19,6 +19,7 @@ Check out the GitHub repo for setup instructions: https://github.com/Sopheakmorm
     <PackageTags>tracing log structured NLog Telegram</PackageTags>
     <PackageReleaseNotes>
 Added support for Net45 + NetStandard2.0
+Added Layout support for BaseUrl + BotToken + ChatId
     </PackageReleaseNotes>
   </PropertyGroup>
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
-NLog.Telegram
+NLog.Telegram.Format
 ==========
 
-An NLog target for Telegram with the avaiable format which provided by Telgram.
-Available format:
-  MARKDOWN
-  HTML5
-for more : https://core.telegram.org/bots/api#formatting-options
+An NLog target for Telegram with the avaiable format which provided by Telegram.
 
-This repository referenced by : https://github.com/narfunikita/NLog.Telegram
+[![Version](https://badge.fury.io/nu/NLog.Telegram.Format.svg)](https://www.nuget.org/packages/NLog.Telegram.Format)
+
+Code forked from repository : https://github.com/narfunikita/NLog.Telegram
 
 ------------
 
@@ -16,7 +14,7 @@ Usage
 1. Create a TelegramBot(https://core.telegram.org/bots#3-how-do-i-create-a-bot).
 2. Configure NLog to use `NLog.Telegram.Format`: https://github.com/nlog/nlog/wiki/Configuration-file
 
-### NLog.config
+### Example NLog.config
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -29,11 +27,10 @@ Usage
 
   <targets async="true">
     <target xsi:type="Telegram"
-            name ="telegramTarget"
-			layout="${message}"
-            botToken ="xxx"
+            name="telegramTarget"
+            layout="${message}"
+            botToken="xxx"
             chatId="xxx"
-            format="MARKDOWN"
             />
   </targets>
 
@@ -43,21 +40,22 @@ Usage
 </nlog>
 ```
 ---------
-### Example
+### Example Formatting
 ```csharp
 	var log = LogManager.GetCurrentClassLogger();
 
 	log.Debug($"`hello world` **hello world** __hello world__");
 ```
 
+For more: https://core.telegram.org/bots/api#formatting-options
+
 ### Configuration Options
 
 Key        | Description
 ----------:| -----------
-BotToken    | Your telegram bot token (e.g 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11)
-ChatId   | Unique identifier for the message recipient � User or GroupChat id
-BaseUrl | Optional. Api bot Url. Default: https://api.telegram.org/bot
-Format | Optional. Render layout for telegram message. Default : DEFAULT
+BotToken   | Your telegram bot token (e.g 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11)
+ChatId     | Unique identifier for the message recipient � User or GroupChat id
+BaseUrl    | Optional. Api bot Url. Default: https://api.telegram.org/bot
 
 ----------
 Reference: https://github.com/narfunikita/NLog.Telegram


### PR DESCRIPTION
Now `BaseUrl` + `BotToken` + `ChatId` can be rendered using NLog Layout-logic, so one can get values from appsetting.json or app.config